### PR TITLE
ignore /password/recover in seo indexer

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,6 +7,7 @@ Disallow: /user
 Disallow: /account
 Disallow: /api
 Disallow: /password
+Disallow: /password/recover
 Disallow: /api_tokens
 Disallow: /cart_link
 Disallow: /account_link


### PR DESCRIPTION
should fix 
![image](https://user-images.githubusercontent.com/9078616/140626144-a2c6e6af-6763-4b5a-bc0a-00cdd3404183.png)
